### PR TITLE
ED-8580: Fix API key reference in RestApiAuthorizerImpl

### DIFF
--- a/src/main/java/com/drajer/bsa/auth/impl/RestApiAuthorizerImpl.java
+++ b/src/main/java/com/drajer/bsa/auth/impl/RestApiAuthorizerImpl.java
@@ -2,8 +2,7 @@ package com.drajer.bsa.auth.impl;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 
@@ -14,18 +13,22 @@ import com.drajer.bsa.model.KarProcessingData;
 public class RestApiAuthorizerImpl implements RestApiAuthorizationHeaderIf {
     private final Logger logger = LoggerFactory.getLogger(RestApiAuthorizerImpl.class);
 
-    @Autowired private Environment environment;
+    @Value("${rxnt.api.key}")
+    String apiKey;
 
     @Override
     public HttpHeaders getAuthorizationHeader(KarProcessingData data) {
 
         HttpHeaders headers = new HttpHeaders();
         logger.info("Fetching the AccessToken");
-
-        String securityToken = environment.getRequiredProperty("rxnt.api.key");
+        
+        if (apiKey == null || apiKey.isEmpty()) {
+            logger.error("Invalid API key");
+        }
 
         // Set Authorization Header
-        headers.add("X-Api-Key", securityToken);
+        headers.add("X-API-Key", apiKey);
+
         return headers;
     }
 }

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,4 +1,4 @@
-jdbc.url=jdbc:postgresql://postgresdb:5432/ecr-now-app
+jdbc.url=jdbc:postgresql://localhost:5432/ecr-now-app
 jdbc.username=postgres
 jdbc.password=postgres
 security.key=test123
@@ -7,9 +7,9 @@ ersd.file.location=C:/RXNTSrc/ecr-now-app/ecrNow/src/main/resources/artifacts/de
 schematron.file.location=C:/RXNTSrc/ecr-now-app/ecrNow/src/main/resources/artifacts/CDAR2_IG_PHCASERPT_R2_STU1.1_SCHEMATRON.sch
 xsd.schemas.location=C:/RXNTSrc/ecr-now-app/ecrNow/src/main/resources/artifacts/CDA_SDTC.xsd
 
-rxnt.api.key=tbd
+rxnt.api.key=ehrv8-extn-api-key
 
-bsa.output.directory=C:/RXNTSrc/ecr-now-app/ecrNow/src/target/output/bsa
+bsa.output.directory=C:/RXNTSrc/ecr-now-app/ecrNow/target/output/bsa
 kar.directory=C:/RXNTSrc/ecr-now-app/ecrNow/src/main/resources/artifacts
 
-server.port=4000 
+server.port=4000

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -4,7 +4,7 @@ jdbc.password=@Microsoft.KeyVault(SecretUri=https://prod-baseinfra-az-vault.vaul
 security.key=@Microsoft.KeyVault(SecretUri=https://prod-baseinfra-az-vault.vault.azure.net/secrets/ecr-security-key)
 
 logging.file.name=/mounts/storage/ECR/logs/ecrNow.log
-ersd.file.location=/opt/app/artifacts/ersd.json
+ersd.file.location=/opt/app/artifacts/dev/ersd.json
 schematron.file.location=/opt/app/artifacts/CDAR2_IG_PHCASERPT_R2_STU1.1_SCHEMATRON.sch
 xsd.schemas.location=/opt/app/artifacts/CDA_SDTC.xsd
 

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -4,7 +4,7 @@ jdbc.password=@Microsoft.KeyVault(SecretUri=https://prod-baseinfra-az-vault.vaul
 security.key=@Microsoft.KeyVault(SecretUri=https://prod-baseinfra-az-vault.vault.azure.net/secrets/ecr-security-key)
 
 logging.file.name=/mounts/storage/ECR/logs/ecrNow.log
-ersd.file.location=/opt/app/artifacts/dev/ersd.json
+ersd.file.location=/opt/app/artifacts/ersd.json
 schematron.file.location=/opt/app/artifacts/CDAR2_IG_PHCASERPT_R2_STU1.1_SCHEMATRON.sch
 xsd.schemas.location=/opt/app/artifacts/CDA_SDTC.xsd
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,7 +39,7 @@ ecr.fhir.skip.triggerquery.resources=Patient|Encounter
 ecr.rr.processorphanrr=false
 token.validator.class=
 
-authorization.service.impl.class=com.drajer.ecrapp.security.RestApiAuthorizerImpl
+authorization.service.impl.class=com.drajer.bsa.auth.impl.RestApiAuthorizerImpl
 # Enable debug output for db-scheduler, just to visualize what's going on
 logging.level.com.github.kagkarlsson.scheduler=DEBUG
 
@@ -77,7 +77,7 @@ SofSystem=com.drajer.bsa.security.SystemLaunchAuthenticator
 # Used for LaunchPatient API
 kar.directory=
 bsa.output.directory=
-save.debug.files=false
+save.debug.files=true
 enable.throttling=true
 
 # Throttle recheck interval if the infrastructure is busy in minutes
@@ -119,4 +119,4 @@ pool.max.per.route=60
 pool.max.total=60
 connection.request.time.out=60
 rest.template.connection.timeout=10000
-rest.template.read.timeout=10000
+rest.template.read.timeout=30000


### PR DESCRIPTION
_Changes in this PR_
* Update `save.debug.files` config to save debug files to `bsa.output.directory` folder path
* Increase the `rest.template.read.timeout` from 10000 to 30000 because the app is timing out waiting for a response from _/EHRV8ExtnAPIServices/ehrv8/ecr/send-direct-email_ (https://github.com/RXNT/ehr-apps/pull/3846)
* Fix `RestApiAuthorizerImpl` reference to keyvault API key in env config

_Local Testing_
Request to _/launchPatient_ shows eICR generated & direct email sent successfully in logs
![image](https://github.com/RXNT/eCRNow/assets/46542534/51ce17f5-6ad1-42f8-b39d-0bc18d242829)

ph_messages entry created in Postgres
![image](https://github.com/RXNT/eCRNow/assets/46542534/af7e8fcf-3463-44d9-9712-288dad79b2ac)

