### PR TITLE
ED-8580: Fix JSON request to EHRV8ExtensionAPI

### DIFF
--- a/src/main/java/com/drajer/ecrapp/model/RXNTRrReceiverRequest.java
+++ b/src/main/java/com/drajer/ecrapp/model/RXNTRrReceiverRequest.java
@@ -2,13 +2,31 @@ package com.drajer.ecrapp.model;
 
 public class RXNTRrReceiverRequest {
     /** The FHIR Server for the EHR initiating the launch. */
-    private int EncounterId;
-    private int PatientId;
+    private String RrId;
+    private String EncounterId;
+    private String PatientId;
     private String RrXml;
 
-    public RXNTRrReceiverRequest(int encounterId, int patientId, String rrXml) {
+    public RXNTRrReceiverRequest(String rrId, String encounterId, String patientId, String rrXml) {
         EncounterId = encounterId;
         PatientId = patientId;
         RrXml = rrXml;
+        RrId = rrId;
+    }
+
+    public String getEncounterId() {
+        return EncounterId;
+    }
+
+    public String getPatientId() {
+        return PatientId;
+    }
+
+    public String getRrXml() {
+        return RrXml;
+    }
+
+    public String getRrId() {
+        return RrId;
     }
 }


### PR DESCRIPTION
# What is this about
<!-- 
Add the ticket link to make it easier for the reviewer to check requirements.
Important: remember to add the ticket # into the PR title.
-->
[**ED-8580**](https://rxnttracker.atlassian.net/browse/ED-8580)

> [!IMPORTANT]  
> USE LABELS TO CATEGORIZE THIS PR

<!-- Add below a summary of changes that were made in this PR -->
_Changes in this PR_
Fix references to patient & encounter ids, & create method to construct JSON request to the EHRV8 Extension API (related PR: https://github.com/RXNT/ehr-apps/pull/4081)

## How to reproduce and what is root cause (when bugs)
<!-- Explain step by step how to reproduce this issue -->
replace_this

## How it was solved
<!--
This is important to bring the reviewer to your thought process while resolving this. Also, this avoids questions related to the implementation details.
- *if proposed solution is not optimal, please add some context why*
- *if this is just a workaround fix, please create a follow-up tech-debt ticket to solve this as optimal as possible*
-->
replace_this


## What test flows cover this change?  Which manual tests, or automated tests?
<!--

-->
What steps should a 3rd party take to verify this change is functionally correct, and does not break existing user workflows or system behavior?

Local integration testing & production testing
eCRNow app logs
```
2024-05-20 20:54:58.041  INFO 49488 --- [http-nio-4000-exec-1] c.drajer.bsa.model.PublicHealthMessage   : PublicHealthMessage initiated.
2024-05-20 20:54:58.043  INFO 49488 --- [http-nio-4000-exec-1] c.d.bsa.service.impl.RrReceiverImpl      :  Found the ecr for doc Id = fd3bb8d3-53f6-4697-972a-e97a1d8f6da8
2024-05-20 20:54:58.046  WARN 49488 --- [http-nio-4000-exec-1] org.hibernate.orm.deprecation            : HHH90000022: Hibernate's legacy org.hibernate.Criteria API is deprecated; use the JPA javax.persistence.criteria.CriteriaQuery instead
2024-05-20 20:54:58.049  WARN 49488 --- [http-nio-4000-exec-1] org.hibernate.orm.deprecation            : HHH90000022: Hibernate's legacy org.hibernate.Criteria API is deprecated; use the JPA javax.persistence.criteria.CriteriaQuery instead
2024-05-20 20:54:58.053  INFO 49488 --- [http-nio-4000-exec-1] c.d.b.d.impl.HealthcareSettingsDaoImpl   :  Adding Kar Id rctc-release-1.2.0.0-Bundle-rctc|1.2.0.0 to active Kars
2024-05-20 20:54:58.054  INFO 49488 --- [http-nio-4000-exec-1] c.d.bsa.service.impl.RrReceiverImpl      : getHandOffResponseToRestApi is not empty
2024-05-20 20:54:58.054  INFO 49488 --- [http-nio-4000-exec-1] c.d.bsa.service.impl.RrReceiverImpl      : Public Health Message:com.drajer.bsa.model.PublicHealthMessage@462d17c0
2024-05-20 20:54:58.054  INFO 49488 --- [http-nio-4000-exec-1] c.d.bsa.service.impl.RrReceiverImpl      : Cda Rr Model:com.drajer.cda.parser.CdaRrModel@13ae9b83
2024-05-20 20:54:58.057  INFO 49488 --- [http-nio-4000-exec-1] c.d.bsa.auth.impl.RestApiAuthorizerImpl  : Fetching the AccessToken
2024-05-20 20:55:00.456 DEBUG 49488 --- [db-scheduler-execute-due-pool-2-thread-1] com.github.kagkarlsson.scheduler.Waiter  : Waiter start wait.
2024-05-20 20:55:08.407  INFO 49488 --- [http-nio-4000-exec-1] c.d.bsa.service.impl.RrReceiverImpl      : Request JSON: {"EncounterId":"enc-id-14308972","PatientId":"pa-id-279860997","RrId":"ce3bb6db-4e99-4b65-92f1-b41f5085938a","RrXml":"<ClinicalDocument
```

## Before/After images or gifs showing the feature/fix (when applicable)
<!--
> *[Chromium Screen Recorder](https://chrome.google.com/webstore/detail/screen-recorder/hniebljpgcogalllopnjokppmgbhaden?hl=en)*
> Windows 11 region screenshot: `Win + Shift + S`
> MacOS region screenshot: `Cmd + Shift + 4`
-->


<!-- 
📢 Goes without saying:
> - ⚙️ Project is building fine
> - 💪 These changes improve our code quality and test coverage
> - ✅ My changes did not break other tests
> - 📃 [PR Process](https://docs.google.com/document/d/1oY8vRjroXgIjxV4Y7sRwE2QfFf65rJic_bsdxnVl3I8)
> - 📃 Best practices for [Cloud Native](https://docs.google.com/document/d/1PMO9e_dVWMIrZAQ-5lXH5mwVelIjCEDio16VA1viUpU) and [Javascript](https://docs.google.com/document/d/1R0t0KbLj5L-rRRj31XStC9tvZs82n9t2zGciRQYst_8).
-->
## Security Checklist

### Configuration
- [ ] Sensitive data is not hard-coded in configuration files
- [ ] Develop and test code are properly segregated from production
- [ ] Dependencies are up to date

### Secure Transmission
- [ ] Sensitive data is only transmitted over an SSL connection
- [ ] Site is partitioned into private and public URLs
- [ ] Sensitive data has been secured in memory, storage and transit
- [ ] Sensitive data doesn’t leak to non private channels


### Authentication
- [ ] Test for user enumeration
- [ ] Passwords are encrypted using a framework / library
- [ ] Users are unable to login over GET, only POST
- [ ] User credentials are encrypted using framework/library 
- [ ] Strong password policy in effect

### Session Management
- [ ] Establish how session management is handled in the application
- [ ] Session cookies are encrypted and have a length of at least 128 bits and are complex
- [ ] Session cookies are not persistent
- [ ] Session cookies use cookie attributes httponly, secure, samesite
- [ ] Session tokens are not passed in URLs
- [ ] Session Cookies expire in a reasonable amount of time
- [ ] Logout will invalidate the session

### Authorization
- [ ] Sensitive transactions require re authentication
- [ ] Authentication and Authorization checks are done on each private request
- [ ] Authorization checks are granular, per page / directory / action
- [ ] Authorization checks are appropriate for each HTTP Verb the application supports


### Data Validation
- [ ] All user input is validated for proper type, length, format and range
- [ ] Validation on user input is done server side
- [ ] Uploaded files are validated for content type, size, file type and filename
- [ ] Special characters are sanitized before being used in external systems, like databases
- [ ] Does invalid input trigger handled exceptions

### Application Output
- [ ] All page output is properly encoded
- [ ] All header output is URL encoded
- [ ] Cache headers are properly set on sensitive data
- [ ] Security headers are properly set on the application
- [ ] Sensitive Application information is not revealed to the user
- [ ] Error messages don’t reveal sensitive information
- [ ] Error messages aren't user controllable

### Cryptography
- [ ] User passwords are encrypted using a stretching algorithm and uniquely salted
- [ ] Block ciphers operate in CBC and IV values are not reused
- [ ] Salts are unique per user, have over 64 bits of secure random data
- [ ] Check for known bad ciphers (RC4), cryptographic hash functions (MD5) and insecure random number generation

### Log Management
- [ ] All sensitive user actions are logged with the following: Where, What, When, Who, How answered
- [ ] All sensitive system actions are logged with the following: Where, What, When, Who, How answered
- [ ] Sensitive info is not logged
- [ ] User input is sanitized and validated before being placed in application logs